### PR TITLE
Support data classes via RedactedBase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .iml
 .project
 .classpath
+bin/

--- a/redacted-compiler-plugin-annotation/src/main/kotlin/io/sweers/redacted/annotation/RedactedBase.kt
+++ b/redacted-compiler-plugin-annotation/src/main/kotlin/io/sweers/redacted/annotation/RedactedBase.kt
@@ -1,0 +1,15 @@
+package io.sweers.redacted.annotation
+
+/**
+ * A base class to extend to enable redacted support in data classes. Just make your data class
+ * extend this class.
+ */
+abstract class RedactedBase {
+  final override fun toString(): String {
+    return toRedactedString()
+  }
+
+  open fun toRedactedString(): String {
+    return "<will be overridden>"
+  }
+}

--- a/sample/src/main/kotlin/io/sweers/sample/Person.kt
+++ b/sample/src/main/kotlin/io/sweers/sample/Person.kt
@@ -1,8 +1,14 @@
 package io.sweers.sample
 
 import io.sweers.redacted.annotation.Redacted
+import io.sweers.redacted.annotation.RedactedBase
 
-class Person(
+data class Person(
+    val name: String,
+    @Redacted val ssn: String
+) : RedactedBase()
+
+class NonDataPerson(
     val name: String,
     @Redacted val ssn: String
 )

--- a/sample/src/main/kotlin/io/sweers/sample/Runner.kt
+++ b/sample/src/main/kotlin/io/sweers/sample/Runner.kt
@@ -6,7 +6,9 @@ class Runner {
     @JvmStatic
     fun main(args: Array<String>) {
       val person = Person("John Doe", "123-456-7890")
+      val nonDataPerson = NonDataPerson("John Doe", "123-456-7890")
       println(person.toString())
+      println(nonDataPerson.toString())
     }
   }
 }


### PR DESCRIPTION
This is a not-so-clever workaround to support data classes via `RedactedBase` base class, which overrides `toString()` as `final` and points to an open `toRedactedString()` function that the kotlin built-in data class `toString()` generator won't conflict with. It'd be ideal if we could somehow set this superclass automagically during compilation.

```kotlin
data class Person(
    val name: String,
    @Redacted val ssn: String
) : RedactedBase()

class NonDataPerson(
    val name: String,
    @Redacted val ssn: String
)

val person = Person("John Doe", "123-456-7890")
val nonDataPerson = NonDataPerson("John Doe", "123-456-7890")
println(person.toString())
println(nonDataPerson.toString())

// -> Person(name=John Doe, ssn="██")
// -> NonDataPerson(name=John Doe, ssn="██")
```