### PR TITLE
Add gradle plugin module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,17 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
-
     repositories {
+        mavenLocal()
         jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "io.sweers.redacted:redacted-compiler-gradle-plugin:$version"
     }
 }
 
 allprojects {
     repositories {
+        mavenLocal()
         jcenter()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+kotlin_version=1.3.61
+autoservice_version=1.0-rc6
+
+group=io.sweers.redacted
+version=0.0.1

--- a/redacted-compiler-gradle-plugin/build.gradle
+++ b/redacted-compiler-gradle-plugin/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id "com.gradle.plugin-publish" version "0.10.1"
+}
+
+apply plugin: "java-gradle-plugin"
+apply plugin: "org.jetbrains.kotlin.jvm"
+apply plugin: "org.jetbrains.kotlin.kapt"
+apply plugin: "maven-publish"
+
+gradlePlugin {
+    plugins {
+        redactedPlugin {
+            id = 'io.sweers.redacted.redacted-plugin'
+            implementationClass = 'io.sweers.redacted.gradle.RedactedGradlePlugin'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlin_version"
+
+    compileOnly "com.google.auto.service:auto-service:$autoservice_version"
+    kapt "com.google.auto.service:auto-service:$autoservice_version"
+}
+
+pluginBundle {
+    website = 'https://github.com/ZacSweers/redacted-compiler-plugin/'
+    vcsUrl = 'https://github.com/ZacSweers/redacted-compiler-plugin/'
+    description = 'Redacted Compiler Gradle Plugin'
+    tags = ['kotlin', 'compiler', 'plugin']
+    plugins {
+        redactedPlugin {
+            displayName = 'Redacted Compiler Gradle Plugin'
+        }
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/redacted-compiler-gradle-plugin/src/main/kotlin/io/sweers/redacted/gradle/RedactedGradlePlugin.kt
+++ b/redacted-compiler-gradle-plugin/src/main/kotlin/io/sweers/redacted/gradle/RedactedGradlePlugin.kt
@@ -1,0 +1,15 @@
+package io.sweers.redacted.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class RedactedGradlePlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    target.extensions.create("redactedPlugin", RedactedPluginExtension::class.java)
+  }
+}
+
+open class RedactedPluginExtension {
+  var enabled: Boolean = true
+  var replacementString: String = "██"
+}

--- a/redacted-compiler-gradle-plugin/src/main/kotlin/io/sweers/redacted/gradle/RedactedGradleSubplugin.kt
+++ b/redacted-compiler-gradle-plugin/src/main/kotlin/io/sweers/redacted/gradle/RedactedGradleSubplugin.kt
@@ -1,0 +1,42 @@
+package io.sweers.redacted.gradle
+
+import com.google.auto.service.AutoService
+import org.gradle.api.Project
+import org.gradle.api.tasks.compile.AbstractCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+
+@AutoService(KotlinGradleSubplugin::class)
+class RedactedGradleSubplugin : KotlinGradleSubplugin<AbstractCompile> {
+
+  override fun isApplicable(project: Project, task: AbstractCompile): Boolean =
+      project.plugins.hasPlugin(RedactedGradlePlugin::class.java)
+
+  override fun getCompilerPluginId(): String = "redacted-compiler-plugin"
+
+  override fun getPluginArtifact(): SubpluginArtifact =
+      SubpluginArtifact(
+          groupId = "io.sweers.redacted",
+          artifactId = "redacted-compiler-plugin",
+          version = "0.0.1" // TODO: What's the best way to keep this synced?
+      )
+
+  override fun apply(
+      project: Project,
+      kotlinCompile: AbstractCompile,
+      javaCompile: AbstractCompile?,
+      variantData: Any?,
+      androidProjectHandler: Any?,
+      kotlinCompilation: KotlinCompilation<KotlinCommonOptions>?
+  ): List<SubpluginOption> {
+    val extension = project.extensions.findByType(RedactedPluginExtension::class.java) ?: RedactedPluginExtension()
+
+    return listOf(
+        SubpluginOption(key = "enabled", value = extension.enabled.toString()),
+        SubpluginOption(key = "replacementString", value = extension.replacementString)
+    )
+  }
+}

--- a/redacted-compiler-plugin-annotation/build.gradle
+++ b/redacted-compiler-plugin-annotation/build.gradle
@@ -1,7 +1,16 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'maven-publish'
 
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
+  }
+}
+
+publishing {
+  publications {
+    maven(MavenPublication) {
+      from components.java
+    }
   }
 }

--- a/redacted-compiler-plugin-annotation/build.gradle
+++ b/redacted-compiler-plugin-annotation/build.gradle
@@ -7,6 +7,10 @@ compileKotlin {
   }
 }
 
+dependencies {
+  compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+}
+
 publishing {
   publications {
     maven(MavenPublication) {

--- a/redacted-compiler-plugin/build.gradle
+++ b/redacted-compiler-plugin/build.gradle
@@ -1,10 +1,11 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.kapt'
+apply plugin: 'maven-publish'
 
 compileKotlin {
   kotlinOptions {
     jvmTarget = "1.8"
-    freeCompilerArgs = ['-Xskip-runtime-version-check', 'true']
+    //freeCompilerArgs = ['-Xskip-runtime-version-check', 'true']
   }
 }
 
@@ -13,6 +14,15 @@ dependencies {
   compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
   compile "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
 
-  compile "com.google.auto.service:auto-service:1.0-rc4"
-  kapt "com.google.auto.service:auto-service:1.0-rc4"
+  compile "com.google.auto.service:auto-service:$autoservice_version"
+  kapt "com.google.auto.service:auto-service:$autoservice_version"
+}
+
+
+publishing {
+  publications {
+    maven(MavenPublication) {
+      from components.java
+    }
+  }
 }

--- a/redacted-compiler-plugin/src/main/kotlin/io/sweers/redacted/compiler/RedactedCommandLineProcessor.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/io/sweers/redacted/compiler/RedactedCommandLineProcessor.kt
@@ -1,0 +1,33 @@
+package io.sweers.redacted.compiler
+
+import com.google.auto.service.AutoService
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+
+val KEY_ENABLED = CompilerConfigurationKey<Boolean>("enabled")
+val KEY_REPLACEMENT_STRING = CompilerConfigurationKey<String>("replacementString")
+
+@AutoService(CommandLineProcessor::class)
+class RedactedCommandLineProcessor : CommandLineProcessor {
+
+  override val pluginId: String = "redacted-compiler-plugin"
+
+  override val pluginOptions: Collection<AbstractCliOption> =
+      listOf(
+          CliOption("enabled", "<true | false>", "", required = true),
+          CliOption("replacementString", "String", "", required = true)
+      )
+
+  override fun processOption(
+      option: AbstractCliOption,
+      value: String,
+      configuration: CompilerConfiguration
+  ) = when (option.optionName) {
+    "enabled" -> configuration.put(KEY_ENABLED, value.toBoolean())
+    "replacementString" -> configuration.put(KEY_REPLACEMENT_STRING, value)
+    else -> error("Unknown plugin option: ${option.optionName}")
+  }
+}

--- a/redacted-compiler-plugin/src/main/kotlin/io/sweers/redacted/compiler/RedactedPlugin.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/io/sweers/redacted/compiler/RedactedPlugin.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.codegen.extensions.ExpressionCodegenExtension
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.Extensions
-import org.jetbrains.kotlin.com.intellij.openapi.extensions.LoadingOrder
 import org.jetbrains.kotlin.com.intellij.openapi.extensions.impl.ExtensionPointImpl
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
@@ -20,12 +19,15 @@ class TestComponentRegistrar : ComponentRegistrar {
   override fun registerProjectComponents(project: MockProject,
       configuration: CompilerConfiguration) {
 
+    if (configuration[KEY_ENABLED] == false) return
+
     // see https://github.com/JetBrains/kotlin/blob/1.1.2/plugins/annotation-collector/src/org/jetbrains/kotlin/annotation/AnnotationCollectorPlugin.kt#L92
     val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
         MessageCollector.NONE)
 
+    val replacementString = checkNotNull(configuration[KEY_REPLACEMENT_STRING])
     ExpressionCodegenExtension.registerExtensionAsFirst(project,
-        RedactedCodegenExtension(messageCollector))
+        RedactedCodegenExtension(messageCollector, replacementString))
 
     SyntheticResolveExtension.registerExtensionAsFirst(project,
         RedactedSyntheticResolveExtension(messageCollector))
@@ -36,5 +38,5 @@ fun <T> ProjectExtensionDescriptor<T>.registerExtensionAsFirst(project: Project,
   Extensions.getArea(project)
       .getExtensionPoint(extensionPointName)
       .let { it as ExtensionPointImpl }
-      .registerExtension(extension, LoadingOrder.LAST)
+      .registerExtension(extension, project)
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,22 +1,11 @@
-def compilerPlugin = project(':redacted-compiler-plugin')
-
-evaluationDependsOn(":$compilerPlugin.name")
-
 apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'io.sweers.redacted.redacted-plugin'
 
-def pluginJar = new File(compilerPlugin.buildDir, "libs/${compilerPlugin.name}.jar").toString()
-compileKotlin {
-  kotlinOptions {
-    freeCompilerArgs = ["-Xplugin=$pluginJar"]
-  }
+redactedPlugin {
+  enabled = true
 }
 
 dependencies {
   compileOnly project(':redacted-compiler-plugin-annotation')
-  compile project(':redacted-compiler-plugin-annotation')
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-}
-
-afterEvaluate {
-  tasks["compileKotlin"].dependsOn += compilerPlugin.tasks["jar"]
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'redacted-compiler-plugin'
 include ':redacted-compiler-plugin'
 include ':redacted-compiler-plugin-annotation'
+include ':redacted-compiler-gradle-plugin'
 include ':sample'
 


### PR DESCRIPTION
This plugin allows consumers to easily apply the library as a plugin and companion jvm artifact.

Currently the sample requires local publishing to compile, this can be done using `./gradlew publishToMavenLocal`.  If you'd like, I can add project properties to support bintray publishing.  You can also publish the gradle plugin to the gradle portal using `./gradlew publishPlugins`.

The gradle config is:
```
redactedPlugin {
  enabled = true
  replacementString = "██"
}
```
