### PR TITLE
Implement android per-variant configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ci_java_version: [1.8, 9, 10, 11, 12, 13]
+        ci_java_version: [1.8, 11, 12, 13]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .project
 .classpath
 *.iml
+local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .iml
 .project
 .classpath
+*.iml

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ in most multi-variant projects anyway, but something to be aware of.
 
 ```groovy
 redacted {
-  // ...
+  enabled = true // Default
   androidVariantFilter {
+    // Don't enable on debug
     if (buildType.name == "debug") {
       overrideEnabled(false)
     }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,28 @@ redacted {
   enabled = true // Default
   replacementString = "██" // Default
 }
+```
 
+### Android Per-Variant Configuration
+
+If using Android, you can optionally configure the plugin to be applied on a per-variant basis via
+`androidVariantFilter`. This is similar to the Android Gradle Plugin's native `variantFilter` API,
+except with an `overrideEnabled` function to override the enabled status and there is no
+`defaultConfig` property. If not overridden, the default is to match the `redacted` extension's value.
+Other `VariantFilter` APIs should behave as expected (buildType, flavors, name, etc).
+
+_Note:_ Variants with different `enabled` values will have to be compiled separately. This is common
+in most multi-variant projects anyway, but something to be aware of.
+
+```groovy
+redacted {
+  // ...
+  androidVariantFilter {
+    if (buildType.name == "debug") {
+      overrideEnabled(false)
+    }
+  }
+}
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snapshots].

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         mavenCentral()
         jcenter()
     }
@@ -7,6 +8,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.vanniktech:gradle-maven-publish-plugin:${maven_publish_plugin_version}"
+        classpath "com.android.tools.build:gradle:3.5.3"
         classpath "dev.zacsweers.redacted:redacted-compiler-plugin-gradle"
     }
 }
@@ -14,6 +16,7 @@ buildscript {
 String resolvedJvmTarget = System.getenv().getOrDefault("ci_java_version", "1.8")
 allprojects {
     repositories {
+        google()
         mavenCentral()
         jcenter()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,16 @@ allprojects {
         }
     }
 }
+
+subprojects {
+    configurations.all {
+        resolutionStrategy {
+            dependencySubstitution {
+                // The kotlin plugin will try to add the redacted-compiler-plugin to dependencies with a version
+                // We have it local to this project, so we want it to just substitute that with the local project
+                // Not needed for external consumers
+                substitute module('dev.zacsweers.redacted:redacted-compiler-plugin') with project(':redacted-compiler-plugin')
+            }
+        }
+    }
+}

--- a/redacted-compiler-gradle-plugin/build.gradle
+++ b/redacted-compiler-gradle-plugin/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         ext.set(key, val)
     }
     repositories {
+        google()
         jcenter()
     }
 
@@ -26,6 +27,7 @@ apply plugin: "org.jetbrains.kotlin.kapt"
 apply plugin: "com.vanniktech.maven.publish"
 
 repositories {
+    google()
     jcenter()
 }
 
@@ -62,6 +64,8 @@ gradlePlugin {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlin_version"
+    compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    compileOnly "com.android.tools.build:gradle:3.5.3"
 
     compileOnly "com.google.auto.service:auto-service-annotations:$autoservice_version"
     kapt "com.google.auto.service:auto-service:$autoservice_version"

--- a/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePlugin.kt
+++ b/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePlugin.kt
@@ -1,5 +1,8 @@
 package dev.zacsweers.redacted.gradle
 
+import com.android.builder.model.BuildType
+import com.android.builder.model.ProductFlavor
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -13,4 +16,37 @@ open class RedactedPluginExtension {
   var redactedAnnotation: String? = null
   var enabled: Boolean = true
   var replacementString: String = "██"
+  internal var variantFilter: Action<VariantFilter>? = null
+
+  /**
+   * Applies a variant filter for Android.
+   *
+   * @param action the configure action for the [VariantFilter]
+   */
+  fun androidVariantFilter(action: Action<VariantFilter>) {
+    this.variantFilter = action
+  }
+}
+
+interface VariantFilter {
+  /**
+   * Overrides whether or not to enable this particular variant. Default is whatever is declared in
+   * the extension.
+   */
+  fun overrideEnabled(enabled: Boolean)
+
+  /**
+   * Returns the Build Type.
+   */
+  val buildType: BuildType
+
+  /**
+   * Returns the list of flavors, or an empty list.
+   */
+  val flavors: List<ProductFlavor>
+
+  /**
+   * Returns the unique variant name.
+   */
+  val name: String?
 }

--- a/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
+++ b/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
@@ -1,9 +1,15 @@
 package dev.zacsweers.redacted.gradle
 
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.TestVariant
+import com.android.build.gradle.api.UnitTestVariant
+import com.android.builder.model.BuildType
+import com.android.builder.model.ProductFlavor
 import com.google.auto.service.AutoService
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.jetbrains.kotlin.gradle.internal.KaptVariantData
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
@@ -37,10 +43,53 @@ class RedactedGradleSubplugin : KotlinGradleSubplugin<AbstractCompile> {
       "Redacted annotation must be specified!"
     }
 
+    val extensionFilter = extension.variantFilter
+    var enabled = extension.enabled
+
+    // If we're an android setup
+    if (variantData != null && extensionFilter != null) {
+      val variant = unwrapVariant(variantData)
+      if (variant != null) {
+        project.logger.debug("Resolving enabled status for android variant ${variant.name}")
+        val filter = VariantFilterImpl(variant, enabled)
+        extensionFilter.execute(filter)
+        project.logger.debug("Variant '${variant.name}' redacted flag set to ${filter._enabled}")
+        enabled = filter._enabled
+      } else {
+        project.logger.lifecycle("Unable to resolve variant type for $variantData. Falling back to default behavior of '$enabled'")
+      }
+    }
+
     return listOf(
-        SubpluginOption(key = "enabled", value = extension.enabled.toString()),
+        SubpluginOption(key = "enabled", value = enabled.toString()),
         SubpluginOption(key = "replacementString", value = extension.replacementString),
         SubpluginOption(key = "redactedAnnotation", value = annotation)
     )
   }
+}
+
+private fun unwrapVariant(variantData: Any?): BaseVariant? {
+  return when (variantData) {
+    is BaseVariant -> {
+      when (variantData) {
+        is TestVariant -> variantData.testedVariant
+        is UnitTestVariant -> variantData.testedVariant as? BaseVariant
+        else -> variantData
+      }
+    }
+    is KaptVariantData<*> -> unwrapVariant(variantData.variantData)
+    else -> null
+  }
+}
+
+private class VariantFilterImpl(variant: BaseVariant, enableDefault: Boolean) : VariantFilter {
+  var _enabled: Boolean = enableDefault
+
+  override fun overrideEnabled(enabled: Boolean) {
+    this._enabled = enabled
+  }
+
+  override val buildType: BuildType = variant.buildType
+  override val flavors: List<ProductFlavor> = variant.productFlavors
+  override val name: String = variant.name
 }

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -11,17 +11,6 @@ redacted {
   }
 }
 
-configurations.all {
-  resolutionStrategy {
-    dependencySubstitution {
-      // The kotlin plugin will try to add the redacted-compiler-plugin to dependencies with a version
-      // We have it local to this project, so we want it to just substitute that with the local project
-      // Not needed for external consumers
-      substitute module('dev.zacsweers.redacted:redacted-compiler-plugin') with project(':redacted-compiler-plugin')
-    }
-  }
-}
-
 android {
   compileSdkVersion 29
 

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -1,0 +1,41 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'dev.zacsweers.redacted.redacted-gradle-plugin'
+
+redacted {
+  redactedAnnotation = "dev.zacsweers.redacted.sample.Redacted"
+  androidVariantFilter {
+    if (buildType.name == "debug") {
+      overrideEnabled(false)
+    }
+  }
+}
+
+configurations.all {
+  resolutionStrategy {
+    dependencySubstitution {
+      // The kotlin plugin will try to add the redacted-compiler-plugin to dependencies with a version
+      // We have it local to this project, so we want it to just substitute that with the local project
+      // Not needed for external consumers
+      substitute module('dev.zacsweers.redacted:redacted-compiler-plugin') with project(':redacted-compiler-plugin')
+    }
+  }
+}
+
+android {
+  compileSdkVersion 29
+
+  sourceSets {
+    main.java.srcDirs += 'src/main/kotlin'
+    testDebug.java.srcDirs += 'src/testDebug/kotlin'
+    testRelease.java.srcDirs += 'src/testRelease/kotlin'
+  }
+}
+
+dependencies {
+  implementation project(":sample")
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  
+  testImplementation "junit:junit:4.13"
+  testImplementation "com.google.truth:truth:1.0.1"
+}

--- a/sample-android/src/main/AndroidManifest.xml
+++ b/sample-android/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="dev.zacsweers.redacted.sample.android">
+
+</manifest>

--- a/sample-android/src/main/kotlin/dev/zacsweers/redacted/sample/android/AndroidUser.kt
+++ b/sample-android/src/main/kotlin/dev/zacsweers/redacted/sample/android/AndroidUser.kt
@@ -1,0 +1,5 @@
+package dev.zacsweers.redacted.sample.android
+
+import dev.zacsweers.redacted.sample.Redacted
+
+data class AndroidUser(val name: String, @Redacted val ssn: String)

--- a/sample-android/src/testDebug/AndroidManifest.xml
+++ b/sample-android/src/testDebug/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="dev.zacsweers.redacted.sample.android">
+
+</manifest>

--- a/sample-android/src/testDebug/kotlin/dev/zacsweers/redacted/sample/android/AndroidUserTest.kt
+++ b/sample-android/src/testDebug/kotlin/dev/zacsweers/redacted/sample/android/AndroidUserTest.kt
@@ -1,0 +1,12 @@
+package dev.zacsweers.redacted.sample.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AndroidUserTest {
+  @Test
+  fun debugTestShouldHaveNoRedactions() {
+    val user = AndroidUser("Bob", "123-456-7890")
+    assertThat(user.toString()).isEqualTo("AndroidUser(name=Bob, ssn=123-456-7890)")
+  }
+}

--- a/sample-android/src/testRelease/AndroidManifest.xml
+++ b/sample-android/src/testRelease/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="dev.zacsweers.redacted.sample.android">
+
+</manifest>

--- a/sample-android/src/testRelease/kotlin/dev/zacsweers/redacted/sample/android/AndroidUserTest.kt
+++ b/sample-android/src/testRelease/kotlin/dev/zacsweers/redacted/sample/android/AndroidUserTest.kt
@@ -1,0 +1,12 @@
+package dev.zacsweers.redacted.sample.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AndroidUserTest {
+  @Test
+  fun releaseTestShouldHaveRedactions() {
+    val user = AndroidUser("Bob", "123-456-7890")
+    assertThat(user.toString()).isEqualTo("AndroidUser(name=Bob, ssn=██)")
+  }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,17 +5,6 @@ redacted {
   redactedAnnotation = "dev.zacsweers.redacted.sample.Redacted"
 }
 
-configurations.all {
-  resolutionStrategy {
-    dependencySubstitution {
-      // The kotlin plugin will try to add the redacted-compiler-plugin to dependencies with a version
-      // We have it local to this project, so we want it to just substitute that with the local project
-      // Not needed for external consumers
-      substitute module('dev.zacsweers.redacted:redacted-compiler-plugin') with project(':redacted-compiler-plugin')
-    }
-  }
-}
-
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,11 @@ rootProject.name = 'redacted-compiler-plugin'
 include ':redacted-compiler-plugin'
 include ':sample'
 
+// Only enable android project on JDK 8 until android tools catch up
+if (!JavaVersion.current().isJava9Compatible()) {
+  include ':sample-android'
+}
+
 includeBuild('redacted-compiler-gradle-plugin') {
   dependencySubstitution {
     substitute module('dev.zacsweers.redacted:redacted-compiler-plugin-gradle') with project(':')

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ include ':redacted-compiler-plugin'
 include ':sample'
 
 // Only enable android project on JDK 8 until android tools catch up
-if (!JavaVersion.current().isJava9Compatible()) {
+if (!JavaVersion.current().isJava9Compatible() && System.getenv("ANDROID_HOME") != null) {
   include ':sample-android'
 }
 


### PR DESCRIPTION
Resolves #9 

This opts for option #1 

```groovy
redacted {
  enabled = true
  androidVariantFilter {
    // Don't enable on debug
    if (buildType.name == "debug") {
      overrideEnabled(false)
    }
  }
}
```