### PR TITLE
New option to redact all data classes without supplying annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ redacted {
 
   // Define a custom replacement string for redactions.
   replacementString = "██" // Default
+
+  // Define whether you want to redact every data class regardless of the @Redact annotation. This 
+  // will redact as if you annotated each class
+  redactAllDataClasses = false // Default
 }
 ```
 
@@ -88,6 +92,7 @@ in most multi-variant projects anyway, but something to be aware of.
 ```groovy
 redacted {
   enabled = true // Default
+  redactAllDataClasses = false // Default
   androidVariantFilter {
     // Don't enable on debug
     if (buildType.name == "debug") {

--- a/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
+++ b/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
@@ -10,6 +10,7 @@ open class RedactedPluginExtension {
   var redactedAnnotation: String = DEFAULT_ANNOTATION
   var enabled: Boolean = true
   var replacementString: String = "██"
+  var redactAllDataClasses : Boolean = false
   internal var variantFilter: Action<VariantFilter>? = null
 
   /**
@@ -28,6 +29,12 @@ interface VariantFilter {
    * the extension.
    */
   fun overrideEnabled(enabled: Boolean)
+
+  /**
+   * Overrides whether or not to redact all data classes for this particular variant. Default is whatever is declared in
+   * the extension.
+   */
+  fun overrideRedactAllDataClasses(redactAllDataClasses: Boolean)
 
   /**
    * Returns the Build Type.

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCodegenExtension.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCodegenExtension.kt
@@ -49,7 +49,8 @@ internal const val LOG_PREFIX = "*** REDACTED:"
 class RedactedCodegenExtension(
     private val messageCollector: MessageCollector,
     private val replacementString: String,
-    private val fqRedactedAnnotation: FqName
+    private val fqRedactedAnnotation: FqName,
+    private val redactAllDataClasses: Boolean
 ) : ExpressionCodegenExtension {
 
   private fun log(message: String) {
@@ -63,7 +64,7 @@ class RedactedCodegenExtension(
     val targetClass = codegen.descriptor
     log("Reading ${targetClass.name}")
 
-    val classIsRedacted = targetClass.isRedacted(fqRedactedAnnotation)
+    val classIsRedacted = (redactAllDataClasses && targetClass.isData) || targetClass.isRedacted(fqRedactedAnnotation)
 
     val redactedParams: Boolean
     val properties: List<PropertyDescriptor>

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCommandLineProcessor.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCommandLineProcessor.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.config.CompilerConfigurationKey
 internal val KEY_ENABLED = CompilerConfigurationKey<Boolean>("enabled")
 internal val KEY_REPLACEMENT_STRING = CompilerConfigurationKey<String>("replacementString")
 internal val KEY_REDACTED_ANNOTATION = CompilerConfigurationKey<String>("redactedAnnotation")
+internal val KEY_REDACT_ALL_DATA_CLASSES = CompilerConfigurationKey<Boolean>("redactAllDataClasses")
 
 @AutoService(CommandLineProcessor::class)
 class RedactedCommandLineProcessor : CommandLineProcessor {
@@ -20,7 +21,8 @@ class RedactedCommandLineProcessor : CommandLineProcessor {
       listOf(
           CliOption("enabled", "<true | false>", "", required = true),
           CliOption("replacementString", "String", "", required = true),
-          CliOption("redactedAnnotation", "String", "", required = true)
+          CliOption("redactedAnnotation", "String", "", required = true),
+          CliOption("redactAllDataClasses", "<true | false>", "", required = true),
       )
 
   override fun processOption(
@@ -31,6 +33,7 @@ class RedactedCommandLineProcessor : CommandLineProcessor {
     "enabled" -> configuration.put(KEY_ENABLED, value.toBoolean())
     "replacementString" -> configuration.put(KEY_REPLACEMENT_STRING, value)
     "redactedAnnotation" -> configuration.put(KEY_REDACTED_ANNOTATION, value)
+    "redactAllDataClasses" -> configuration.put(KEY_REDACT_ALL_DATA_CLASSES, value.toBoolean())
     else -> error("Unknown plugin option: ${option.optionName}")
   }
 }

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
@@ -25,12 +25,13 @@ class RedactedComponentRegistrar : ComponentRegistrar {
         MessageCollector.NONE)
     val replacementString = checkNotNull(configuration[KEY_REPLACEMENT_STRING])
     val redactedAnnotation = checkNotNull(configuration[KEY_REDACTED_ANNOTATION])
+    val redactAllDataClasses = configuration[KEY_REDACT_ALL_DATA_CLASSES] == true
     val fqRedactedAnnotation = FqName(redactedAnnotation)
     ExpressionCodegenExtension.registerExtensionAsFirst(project,
-        RedactedCodegenExtension(messageCollector, replacementString, fqRedactedAnnotation))
+        RedactedCodegenExtension(messageCollector, replacementString, fqRedactedAnnotation, redactAllDataClasses))
 
     SyntheticResolveExtension.registerExtensionAsFirst(project,
-        RedactedSyntheticResolveExtension(fqRedactedAnnotation))
+        RedactedSyntheticResolveExtension(fqRedactedAnnotation,redactAllDataClasses))
   }
 }
 

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedSyntheticResolveExtension.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedSyntheticResolveExtension.kt
@@ -19,7 +19,8 @@ import org.jetbrains.kotlin.resolve.extensions.SyntheticResolveExtension
  * with a final descriptor for data classes.
  */
 class RedactedSyntheticResolveExtension(
-    private val fqRedactedAnnotation: FqName
+    private val fqRedactedAnnotation: FqName,
+    private val redactAllDataClasses: Boolean
 ) : SyntheticResolveExtension {
 
   override fun generateSyntheticMethods(
@@ -31,7 +32,7 @@ class RedactedSyntheticResolveExtension(
   ) {
     super.generateSyntheticMethods(thisDescriptor, name, bindingContext, fromSupertypes, result)
 
-    val isRedacted = thisDescriptor.isRedacted(fqRedactedAnnotation) || run {
+    val isRedacted = (redactAllDataClasses && thisDescriptor.isData) || thisDescriptor.isRedacted(fqRedactedAnnotation) || run {
       val constructor = thisDescriptor.constructors.firstOrNull { it.isPrimary } ?: return
       val properties: List<PropertyDescriptor> = constructor.valueParameters
           .mapNotNull { bindingContext.get(BindingContext.VALUE_PARAMETER_AS_PROPERTY, it) }

--- a/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
+++ b/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
@@ -92,6 +92,7 @@ class RedactedPluginTest {
               processor.option(KEY_ENABLED, "true"),
               processor.option(KEY_REPLACEMENT_STRING, "██"),
               processor.option(KEY_REDACTED_ANNOTATION, "dev.zacsweers.redacted.compiler.test.Redacted"),
+              processor.option(KEY_REDACT_ALL_DATA_CLASSES, "false")
           )
           inheritClassPath = true
           sources = sourceFiles.asList() + redacted

--- a/sample-redact-all/build.gradle
+++ b/sample-redact-all/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'dev.zacsweers.redacted.redacted-gradle-plugin'
+
+redacted {
+  redactAllDataClasses true
+}
+
+
+dependencies {
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  
+  testImplementation "junit:junit:4.13"
+  testImplementation "com.google.truth:truth:1.0.1"
+}

--- a/sample-redact-all/src/main/kotlin/dev/zacsweers/redacted/sample/redact/all/CardDetails.kt
+++ b/sample-redact-all/src/main/kotlin/dev/zacsweers/redacted/sample/redact/all/CardDetails.kt
@@ -1,0 +1,7 @@
+package dev.zacsweers.redacted.sample.redact.all
+
+data class CardDetails(
+        val cardNumber: String,
+        val csv: String
+)
+

--- a/sample-redact-all/src/test/kotlin/dev/zacsweers/redacted/sample/redact/all/TotalRedactionTest.kt
+++ b/sample-redact-all/src/test/kotlin/dev/zacsweers/redacted/sample/redact/all/TotalRedactionTest.kt
@@ -1,0 +1,12 @@
+package dev.zacsweers.redacted.sample.redact.all
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class TotalRedactionTest {
+    @Test
+    fun creditCardExample() {
+        val user = CardDetails("386421391737461246123", "238")
+        assertThat(user.toString()).isEqualTo("CardDetails(██)")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'redacted-compiler-plugin'
 include ':redacted-compiler-plugin'
 include ':redacted-compiler-plugin-annotations'
 include ':sample'
+include ':sample-redact-all'
 
 // Only enable android project on JDK 8 until android tools catch up
 if (!JavaVersion.current().isJava9Compatible() && System.getenv("ANDROID_HOME") != null) {


### PR DESCRIPTION
Firstly, this is the first compiler plugin I have worked on so please check thoroughly.

I have a use case where I need to be able to redact all the data classes in my application due to a security pen test highlighting the fact that logic could be exposed due to the inclusion of property names in the `toString()` method of generated classes.

There is never a point where I use the data classes `toString` method for programmatic reasons and if there is I will change to not require that anymore.

Resolves #27 