### PR TITLE
Added capability to redact the name of the enclosing data class

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ redacted {
 
   // Define a custom replacement string for redactions.
   replacementString = "██" // Default
+
+  // Define whether or not class names are output into the toString method or redacted
+  redactClassName = false // Default
 }
 ```
 

--- a/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
+++ b/redacted-compiler-gradle-plugin/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
@@ -10,6 +10,7 @@ open class RedactedPluginExtension {
   var redactedAnnotation: String = DEFAULT_ANNOTATION
   var enabled: Boolean = true
   var replacementString: String = "██"
+  var redactClassName: Boolean = false
   internal var variantFilter: Action<VariantFilter>? = null
 
   /**
@@ -28,6 +29,12 @@ interface VariantFilter {
    * the extension.
    */
   fun overrideEnabled(enabled: Boolean)
+
+  /**
+   * Overrides whether or not to redact the class name for this particular variant. Default is whatever is declared in
+   * the extension.
+   */
+  fun overrideRedactClassName(redactClassName: Boolean)
 
   /**
    * Returns the Build Type.

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCodegenExtension.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCodegenExtension.kt
@@ -49,7 +49,8 @@ internal const val LOG_PREFIX = "*** REDACTED:"
 class RedactedCodegenExtension(
     private val messageCollector: MessageCollector,
     private val replacementString: String,
-    private val fqRedactedAnnotation: FqName
+    private val fqRedactedAnnotation: FqName,
+    private val redactClassName: Boolean
 ) : ExpressionCodegenExtension {
 
   private fun log(message: String) {
@@ -105,7 +106,8 @@ class RedactedCodegenExtension(
         v = codegen.v,
         generationState = codegen.state,
         replacementString = replacementString,
-        fqRedactedAnnotation = fqRedactedAnnotation
+        fqRedactedAnnotation = fqRedactedAnnotation,
+        redactClassName =redactClassName
     ).generateToStringMethod(
         targetClass.findToStringFunction()!!,
         properties
@@ -121,7 +123,8 @@ private class ToStringGenerator(
     private val v: ClassBuilder,
     private val generationState: GenerationState,
     private val replacementString: String,
-    private val fqRedactedAnnotation: FqName
+    private val fqRedactedAnnotation: FqName,
+    private val redactClassName: Boolean
 ) {
   private val typeMapper: KotlinTypeMapper = generationState.typeMapper
   private val underlyingType: JvmKotlinType
@@ -184,56 +187,61 @@ private class ToStringGenerator(
     mv.visitCode()
     AsmUtil.genStringBuilderConstructor(iv)
 
-    if (properties.isEmpty()) {
-      // This is a redacted class, so just emit a single replacementString
-      iv.aconst(classDescriptor.name.toString() + "(" + replacementString)
-      AsmUtil.genInvokeAppendMethod(iv, AsmTypes.JAVA_STRING_TYPE, null)
+    val className = if (redactClassName) replacementString else classDescriptor.name.toString()
+
+    if (redactClassName && properties.isEmpty()) {
+      iv.aconst(replacementString)
     } else {
-      var first = true
-      for (propertyDescriptor in properties) {
-        val isRedacted = propertyDescriptor.isRedacted(fqRedactedAnnotation)
-        val possibleValue = if (isRedacted) replacementString else ""
-        if (first) {
-          iv.aconst(classDescriptor.name.toString() + "(" + propertyDescriptor.name
-              .asString() + "=$possibleValue")
-          first = false
-        } else {
-          iv.aconst(", " + propertyDescriptor.name
-              .asString() + "=$possibleValue")
-        }
+      if (properties.isEmpty()) {
+        // This is a redacted class, so just emit a single replacementString
+        iv.aconst("$className($replacementString")
         AsmUtil.genInvokeAppendMethod(iv, AsmTypes.JAVA_STRING_TYPE, null)
-
-        if (!isRedacted) {
-          val type = genOrLoadOnStack(iv, context, propertyDescriptor, 0)
-          var asmType = type.type
-          var kotlinType = type.kotlinType
-
-          if (asmType.sort == Type.ARRAY) {
-            val elementType = AsmUtil.correctElementType(asmType)
-            if (elementType.sort == Type.OBJECT || elementType.sort == Type.ARRAY) {
-              iv.invokestatic("java/util/Arrays",
-                  "toString",
-                  "([Ljava/lang/Object;)Ljava/lang/String;",
-                  false)
-              asmType = AsmTypes.JAVA_STRING_TYPE
-              kotlinType = function.builtIns
-                  .stringType
-            } else if (elementType.sort != Type.CHAR) {
-              iv.invokestatic("java/util/Arrays",
-                  "toString",
-                  "(" + asmType.descriptor + ")Ljava/lang/String;",
-                  false)
-              asmType = AsmTypes.JAVA_STRING_TYPE
-              kotlinType = function.builtIns
-                  .stringType
-            }
+      } else {
+        var first = true
+        for (propertyDescriptor in properties) {
+          val isRedacted = propertyDescriptor.isRedacted(fqRedactedAnnotation)
+          val possibleValue = if (isRedacted) replacementString else ""
+          if (first) {
+            iv.aconst("$className(" + propertyDescriptor.name
+                    .asString() + "=$possibleValue")
+            first = false
+          } else {
+            iv.aconst(", " + propertyDescriptor.name
+                    .asString() + "=$possibleValue")
           }
-          AsmUtil.genInvokeAppendMethod(iv, asmType, kotlinType, typeMapper)
+          AsmUtil.genInvokeAppendMethod(iv, AsmTypes.JAVA_STRING_TYPE, null)
+
+          if (!isRedacted) {
+            val type = genOrLoadOnStack(iv, context, propertyDescriptor, 0)
+            var asmType = type.type
+            var kotlinType = type.kotlinType
+
+            if (asmType.sort == Type.ARRAY) {
+              val elementType = AsmUtil.correctElementType(asmType)
+              if (elementType.sort == Type.OBJECT || elementType.sort == Type.ARRAY) {
+                iv.invokestatic("java/util/Arrays",
+                        "toString",
+                        "([Ljava/lang/Object;)Ljava/lang/String;",
+                        false)
+                asmType = AsmTypes.JAVA_STRING_TYPE
+                kotlinType = function.builtIns
+                        .stringType
+              } else if (elementType.sort != Type.CHAR) {
+                iv.invokestatic("java/util/Arrays",
+                        "toString",
+                        "(" + asmType.descriptor + ")Ljava/lang/String;",
+                        false)
+                asmType = AsmTypes.JAVA_STRING_TYPE
+                kotlinType = function.builtIns
+                        .stringType
+              }
+            }
+            AsmUtil.genInvokeAppendMethod(iv, asmType, kotlinType, typeMapper)
+          }
         }
       }
+      iv.aconst(")")
     }
-
-    iv.aconst(")")
     AsmUtil.genInvokeAppendMethod(iv, AsmTypes.JAVA_STRING_TYPE, null)
 
     iv.invokevirtual("java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false)

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCommandLineProcessor.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCommandLineProcessor.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.config.CompilerConfigurationKey
 internal val KEY_ENABLED = CompilerConfigurationKey<Boolean>("enabled")
 internal val KEY_REPLACEMENT_STRING = CompilerConfigurationKey<String>("replacementString")
 internal val KEY_REDACTED_ANNOTATION = CompilerConfigurationKey<String>("redactedAnnotation")
+internal val KEY_REDACT_CLASS_NAME = CompilerConfigurationKey<Boolean>("redactClassName")
 
 @AutoService(CommandLineProcessor::class)
 class RedactedCommandLineProcessor : CommandLineProcessor {
@@ -20,7 +21,8 @@ class RedactedCommandLineProcessor : CommandLineProcessor {
       listOf(
           CliOption("enabled", "<true | false>", "", required = true),
           CliOption("replacementString", "String", "", required = true),
-          CliOption("redactedAnnotation", "String", "", required = true)
+          CliOption("redactedAnnotation", "String", "", required = true),
+          CliOption("redactClassName", "<true | false>", "", required = true)
       )
 
   override fun processOption(
@@ -31,6 +33,7 @@ class RedactedCommandLineProcessor : CommandLineProcessor {
     "enabled" -> configuration.put(KEY_ENABLED, value.toBoolean())
     "replacementString" -> configuration.put(KEY_REPLACEMENT_STRING, value)
     "redactedAnnotation" -> configuration.put(KEY_REDACTED_ANNOTATION, value)
+    "redactClassName" -> configuration.put(KEY_REDACT_CLASS_NAME, value.toBoolean())
     else -> error("Unknown plugin option: ${option.optionName}")
   }
 }

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
@@ -26,8 +26,9 @@ class RedactedComponentRegistrar : ComponentRegistrar {
     val replacementString = checkNotNull(configuration[KEY_REPLACEMENT_STRING])
     val redactedAnnotation = checkNotNull(configuration[KEY_REDACTED_ANNOTATION])
     val fqRedactedAnnotation = FqName(redactedAnnotation)
+    val redactClassName = configuration[KEY_REDACT_CLASS_NAME] == true
     ExpressionCodegenExtension.registerExtensionAsFirst(project,
-        RedactedCodegenExtension(messageCollector, replacementString, fqRedactedAnnotation))
+        RedactedCodegenExtension(messageCollector, replacementString, fqRedactedAnnotation,redactClassName))
 
     SyntheticResolveExtension.registerExtensionAsFirst(project,
         RedactedSyntheticResolveExtension(fqRedactedAnnotation))

--- a/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
+++ b/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
@@ -92,6 +92,7 @@ class RedactedPluginTest {
               processor.option(KEY_ENABLED, "true"),
               processor.option(KEY_REPLACEMENT_STRING, "██"),
               processor.option(KEY_REDACTED_ANNOTATION, "dev.zacsweers.redacted.compiler.test.Redacted"),
+              processor.option(KEY_REDACT_CLASS_NAME, "false"),
           )
           inheritClassPath = true
           sources = sourceFiles.asList() + redacted

--- a/sample-redact-class/build.gradle
+++ b/sample-redact-class/build.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'dev.zacsweers.redacted.redacted-gradle-plugin'
+
+redacted {
+  redactClassName true
+}
+
+dependencies {
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  
+  testImplementation "junit:junit:4.13"
+  testImplementation "com.google.truth:truth:1.0.1"
+}

--- a/sample-redact-class/src/main/kotlin/dev/zacsweers/redacted/sample/redact/classname/SecretClass.kt
+++ b/sample-redact-class/src/main/kotlin/dev/zacsweers/redacted/sample/redact/classname/SecretClass.kt
@@ -1,0 +1,6 @@
+package dev.zacsweers.redacted.sample.redact.classname
+
+import dev.zacsweers.redacted.annotations.Redacted
+
+@Redacted
+data class SecretClass(val information: String)

--- a/sample-redact-class/src/main/kotlin/dev/zacsweers/redacted/sample/redact/classname/SecretClassWithRedactedParameters.kt
+++ b/sample-redact-class/src/main/kotlin/dev/zacsweers/redacted/sample/redact/classname/SecretClassWithRedactedParameters.kt
@@ -1,0 +1,5 @@
+package dev.zacsweers.redacted.sample.redact.classname
+
+import dev.zacsweers.redacted.annotations.Redacted
+
+data class SecretClassWithRedactedParameters(@Redacted val secretParameter: String)

--- a/sample-redact-class/src/test/kotlin/dev/zacsweers/redacted/sample/redact/classname/RedactedClassNameTest.kt
+++ b/sample-redact-class/src/test/kotlin/dev/zacsweers/redacted/sample/redact/classname/RedactedClassNameTest.kt
@@ -1,0 +1,18 @@
+package dev.zacsweers.redacted.sample.redact.classname
+
+import com.google.common.truth.Truth
+import org.junit.Test
+
+class RedactedClassNameTest {
+    @Test
+    fun secretClass() {
+        val secret = SecretClass("Sensitive information")
+        Truth.assertThat(secret.toString()).isEqualTo("██")
+    }
+
+    @Test
+    fun secretClassWithRedactedParameters() {
+        val secret = SecretClassWithRedactedParameters("email@address.com")
+        Truth.assertThat(secret.toString()).isEqualTo("██(secretParameter=██)")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'redacted-compiler-plugin'
 include ':redacted-compiler-plugin'
 include ':redacted-compiler-plugin-annotations'
 include ':sample'
+include ':sample-redact-class'
 
 // Only enable android project on JDK 8 until android tools catch up
 if (!JavaVersion.current().isJava9Compatible() && System.getenv("ANDROID_HOME") != null) {


### PR DESCRIPTION
Sometimes you don't want the obfuscated class name from appearing in the `toString` method. This allows that to be redacted. If used in conjunction with the class annotation, the `toString` will just return the replacement string.