### PR TITLE
Handful of IR fixes

### DIFF
--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/ir/RedactedIrVisitor.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/ir/RedactedIrVisitor.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.messages.MessageUtil
 import org.jetbrains.kotlin.descriptors.impl.LazyClassReceiverParameterDescriptor
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -32,6 +33,7 @@ import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.isPrimitiveArray
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.properties
+import org.jetbrains.kotlin.resolve.source.getPsi
 
 internal const val LOG_PREFIX = "*** REDACTED (IR):"
 
@@ -205,7 +207,7 @@ internal class RedactedIrVisitor(
   }
 
   private fun IrClass.reportError(message: String) {
-    val location = CompilerMessageLocation.create(name.asString())
+    val location = MessageUtil.psiElementToMessageLocation(descriptor.source.getPsi())
     messageCollector.report(CompilerMessageSeverity.ERROR, "$LOG_PREFIX $message", location)
   }
 }

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/ir/RedactedIrVisitor.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/ir/RedactedIrVisitor.kt
@@ -166,7 +166,7 @@ internal class RedactedIrVisitor(
         if (property.isRedacted) {
           irConcat.addArgument(irString(replacementString))
         } else {
-          val irPropertyValue = irGetField(irFunction.irThis(), property.ir.backingField!!)
+          val irPropertyValue = irGetField(receiver(irFunction), property.ir.backingField!!)
 
           val param = property.parameter
           val irPropertyStringValue =
@@ -188,14 +188,17 @@ internal class RedactedIrVisitor(
     +irReturn(irConcat)
   }
 
-  private fun IrFunction.irThis(): IrExpression {
-    val dispatchReceiverParameter = dispatchReceiverParameter!!
-    return IrGetValueImpl(
-        startOffset, endOffset,
-        dispatchReceiverParameter.type,
-        dispatchReceiverParameter.symbol
-    )
-  }
+  /**
+   * Only works properly after [mutateWithNewDispatchReceiverParameterForParentClass] has been called on [irFunction].
+   */
+  private fun IrBlockBodyBuilder.receiver(irFunction: IrFunction) =
+          IrGetValueImpl(irFunction.dispatchReceiverParameter!!)
+
+  private fun IrBlockBodyBuilder.IrGetValueImpl(irParameter: IrValueParameter) = IrGetValueImpl(
+          startOffset, endOffset,
+          irParameter.type,
+          irParameter.symbol
+  )
 
   private fun log(message: String) {
     messageCollector.report(CompilerMessageSeverity.LOGGING, "$LOG_PREFIX $message")

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/ir/RedactedOrigin.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/ir/RedactedOrigin.kt
@@ -2,4 +2,4 @@ package dev.zacsweers.redacted.compiler.ir
 
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOriginImpl
 
-internal object RedactedOrigin : IrDeclarationOriginImpl("GENERATED_DATA_API_CLASS_MEMBER")
+internal object RedactedOrigin : IrDeclarationOriginImpl("GENERATED_REDACTED_CLASS_MEMBER")


### PR DESCRIPTION
A few small improvements I found after the initial IR implementation:
* Refactor `generateToStringMethodBody` to includue the `+return` statement, encapsulating the "IR bytecode" calls better.
* Rename and refactor `irThis` to use the builder's offsets rather than the function's. This seems to match the original source code's implementation better.
* Improve the location reported in `reportError` to link to the file that causes the error. (Though I can't verify this because of that one test that reports an internal error for some reason. I couldn't figure that one out.)