### PR TITLE
Add the compiler plugin as an implementation not api

### DIFF
--- a/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
+++ b/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
@@ -66,7 +66,7 @@ class RedactedGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         else -> {
           project
               .configurations
-              .getByName("api")
+              .getByName("implementation")
               .dependencies
               .add(
                   project.dependencies.create(


### PR DESCRIPTION
Similar to https://github.com/square/anvil/pull/43, adding the compiler plugin as an `api` dependency allows consumers to use `@Redacted` in code without the compiler plugin to actually redact the code. This could easily lead to misleading misuse of the annotation and the exposure of sensitive data.

Fixes https://github.com/ZacSweers/redacted-compiler-plugin/issues/76

NOTE: this change is untested