### PR TITLE
Add variant-filter for android and jvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ redacted {
 }
 ```
 
+### Android/JVM Per-Variant Configuration
+
+If using Android of JVM, you can optionally configure the plugin to be applied on a per-variant basis via
+`variantFilter` by setting the `ignore` variable. If no filter is set, the default is to match the `redacted`
+extension's value.
+
+```kotlin
+redacted {
+  enabled = true
+ 
+  variantFilter {
+   when (this) {
+    is AndroidVariantFilter -> ignore = androidVariant.buildType.name == "debug"
+    is JvmVariantFilter -> ignore = name == "test"
+   }
+  }
+}
+```
+
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snapshots].
 
 ## Supported platforms

--- a/redacted-compiler-plugin-gradle/build.gradle.kts
+++ b/redacted-compiler-plugin-gradle/build.gradle.kts
@@ -44,7 +44,10 @@ tasks.named<DokkaTask>("dokkaHtml") {
   dokkaSourceSets.configureEach { skipDeprecated.set(true) }
 }
 
-repositories { mavenCentral() }
+repositories {
+  google()
+  mavenCentral()
+}
 
 spotless {
   format("misc") {
@@ -66,5 +69,6 @@ spotless {
 dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.6.10")
   compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+  compileOnly("com.android.tools.build:gradle:7.1.1")
   implementation("com.google.auto.service:auto-service-annotations:1.0.1")
 }

--- a/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
+++ b/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
@@ -15,6 +15,8 @@
  */
 package dev.zacsweers.redacted.gradle
 
+import dev.zacsweers.redacted.gradle.variant.VariantFilter
+import org.gradle.api.Action
 import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -28,4 +30,15 @@ abstract class RedactedPluginExtension @Inject constructor(objects: ObjectFactor
   val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(true)
 
   val replacementString: Property<String> = objects.property(String::class.java).convention("██")
+
+  @Suppress("PropertyName")
+  internal var _variantFilter: Action<VariantFilter>? = null
+
+  /**
+   * Configures each variant of this project. For Android projects these are the respective
+   * Android variants, for JVM projects these are usually the main and test variant.
+   */
+  fun variantFilter(action: Action<VariantFilter>) {
+    _variantFilter = action
+  }
 }

--- a/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/variant/Variant.kt
+++ b/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/variant/Variant.kt
@@ -1,0 +1,46 @@
+package dev.zacsweers.redacted.gradle.variant
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+internal class Variant private constructor(
+  val project: Project,
+  val compileTaskProvider: TaskProvider<KotlinCompile>,
+  val variantFilter: VariantFilter,
+) {
+  companion object {
+    operator fun invoke(kotlinCompilation: KotlinCompilation<*>): Variant {
+      // Sanity check.
+      require(
+        kotlinCompilation.platformType != KotlinPlatformType.androidJvm ||
+            kotlinCompilation is KotlinJvmAndroidCompilation
+      ) {
+        "The KotlinCompilation is KotlinJvmAndroidCompilation, but the platform type is different."
+      }
+
+      val project = kotlinCompilation.target.project
+      val androidVariant = (kotlinCompilation as? KotlinJvmAndroidCompilation)?.androidVariant
+
+      val commonFilter = CommonFilter(kotlinCompilation.name)
+      val variantFilter = if (androidVariant != null) {
+        AndroidVariantFilter(commonFilter, androidVariant)
+      } else {
+        JvmVariantFilter(commonFilter)
+      }
+
+      @Suppress("UNCHECKED_CAST")
+      return Variant(
+        project = project,
+        compileTaskProvider = kotlinCompilation.compileKotlinTaskProvider as TaskProvider<KotlinCompile>,
+        variantFilter = variantFilter
+      ).also {
+        // Sanity check.
+        check(it.compileTaskProvider.name.startsWith("compile"))
+      }
+    }
+  }
+}

--- a/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/variant/VariantFilter.kt
+++ b/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/variant/VariantFilter.kt
@@ -1,0 +1,24 @@
+package dev.zacsweers.redacted.gradle.variant
+
+import com.android.build.gradle.api.BaseVariant
+import org.gradle.api.Named
+
+interface VariantFilter : Named {
+  var ignore: Boolean
+}
+
+internal class CommonFilter(
+  private val name: String,
+) : VariantFilter {
+  override fun getName(): String = name
+  override var ignore: Boolean = false
+}
+
+class JvmVariantFilter internal constructor(
+  commonFilter: CommonFilter
+) : VariantFilter by commonFilter
+
+class AndroidVariantFilter internal constructor(
+  commonFilter: CommonFilter,
+  val androidVariant: BaseVariant
+) : VariantFilter by commonFilter


### PR DESCRIPTION
Allow configuration per variant for android and jvm projects.

Uses a similar approach as [Anvil](https://github.com/square/anvil/blob/main/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt#L93)