### PR TITLE
Support Unredacted properties and supertype based redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ redacted {
   // classes by '.', e.g. "kotlin/Map.Entry"
   redactedAnnotation = "dev/zacsweers/redacted/annotations/Redacted" // Default
 
+  // Define a custom unredacted annotation.
+  unredactedAnnotation = "dev/zacsweers/redacted/annotations/Unredacted" // Default
+
   // Define whether or not this is enabled. Useful if you want to gate this behind a dynamic
   // build configuration.
   enabled = true // Default
@@ -84,6 +87,42 @@ multiplatform and supports all common JVM, JS, and native targets.
 - Kotlin compiler plugins are not a stable API! Compiled outputs from this plugin _should_ be stable,
 but usage in newer versions of kotlinc are not guaranteed to be stable.
 - IDE support is not currently possible. See [#8](https://github.com/ZacSweers/redacted-compiler-plugin/issues/8).
+
+
+## Advanced Usage
+
+In situations where it is desirable to redact everything and opt-out on certain properties,
+two options are provided:
+
+**Class redaction**
+
+For one-off classes that may contain a large number of fields that should be redacted, you can augment the `@Redacted`
+class behavior:
+
+```kotlin
+@Redacted
+data class User(@Unredacted val name: String, val phoneNumber: String, val ssn: String)
+```
+
+```
+User(name=Bob, phoneNumber=██, ssn=██)
+```
+
+**Supertype redaction**
+
+For situations where you need to enforce that an API only accepts redacted inputs, you can apply `@Redacted` to a
+parent interface.
+
+```kotlin
+@Redacted
+interface RedactedObject
+
+data class User(@Unredacted val name: String, val phoneNumber: String, val ssn: String) : RedactedObject
+```
+
+```
+User(name=Bob, phoneNumber=██, ssn=██)
+```
 
 License
 -------

--- a/redacted-compiler-plugin-annotations/api/redacted-compiler-plugin-annotations.api
+++ b/redacted-compiler-plugin-annotations/api/redacted-compiler-plugin-annotations.api
@@ -1,3 +1,6 @@
 public abstract interface annotation class dev/zacsweers/redacted/annotations/Redacted : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class dev/zacsweers/redacted/annotations/Unredacted : java/lang/annotation/Annotation {
+}
+

--- a/redacted-compiler-plugin-annotations/src/commonMain/kotlin/dev/zacsweers/redacted/annotations/Unredacted.kt
+++ b/redacted-compiler-plugin-annotations/src/commonMain/kotlin/dev/zacsweers/redacted/annotations/Unredacted.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Zac Sweers
+ * Copyright (C) 2024 Zac Sweers
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,21 @@
 package dev.zacsweers.redacted.annotations
 
 import kotlin.annotation.AnnotationRetention.BINARY
-import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.PROPERTY
 
 /**
- * An annotation to indicate that a particular property or class should be redacted in `toString()`
- * implementations. When applied to an interface, subtypes will behave as if the class is annotated
- * with `@Redacted`.
+ * An annotation to indicate that a particular property should NOT be redacted in `toString()`
+ * implementations.
  *
- * For properties, each individual property will be redacted. Example: `User(name=Bob,
- * phoneNumber=██)`
+ * This annotation can be applied to a property in any class that applies `@Redacted` or implements
+ * an interface that applies `@Redacted`.
  *
- * For classes, the entire class will be redacted. Example: `SensitiveData(██)`
+ * Example:
+ * ```
+ * @Redacted
+ * data class User(@Unredacted val name: String, val phoneNumber: String)
+ *
+ * println(user) // User(name = "Bob", phoneNumber = "██")
+ * ```
  */
-@Retention(BINARY) @Target(PROPERTY, CLASS) public annotation class Redacted
+@Retention(BINARY) @Target(PROPERTY) public annotation class Unredacted

--- a/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
+++ b/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradlePluginExtension.kt
@@ -20,6 +20,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 
 internal const val DEFAULT_ANNOTATION = "dev/zacsweers/redacted/annotations/Redacted"
+internal const val DEFAULT_UNREDACTED_ANNOTATION = "dev/zacsweers/redacted/annotations/Unredacted"
 
 public abstract class RedactedPluginExtension @Inject constructor(objects: ObjectFactory) {
   /**
@@ -31,6 +32,9 @@ public abstract class RedactedPluginExtension @Inject constructor(objects: Objec
    */
   public val redactedAnnotation: Property<String> =
     objects.property(String::class.java).convention(DEFAULT_ANNOTATION)
+
+  public val unredactedAnnotation: Property<String> =
+    objects.property(String::class.java).convention(DEFAULT_UNREDACTED_ANNOTATION)
 
   public val enabled: Property<Boolean> =
     objects.property(Boolean::class.javaObjectType).convention(true)

--- a/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
+++ b/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
@@ -45,6 +45,7 @@ public class RedactedGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     val project = kotlinCompilation.target.project
     val extension = project.extensions.getByType(RedactedPluginExtension::class.java)
     val annotation = extension.redactedAnnotation
+    val unredactedAnnotation = extension.unredactedAnnotation
 
     // Default annotation is used, so add it as a dependency
     // Note only multiplatform, jvm/android, and js are supported. Anyone else is on their own.
@@ -62,6 +63,7 @@ public class RedactedGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         SubpluginOption(key = "enabled", value = enabled.toString()),
         SubpluginOption(key = "replacementString", value = extension.replacementString.get()),
         SubpluginOption(key = "redactedAnnotation", value = annotation.get()),
+        SubpluginOption(key = "unredactedAnnotation", value = unredactedAnnotation.get()),
       )
     }
   }

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCommandLineProcessor.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedCommandLineProcessor.kt
@@ -31,6 +31,10 @@ internal val KEY_REDACTED_ANNOTATION =
   CompilerConfigurationKey<String>(
     "The redacted marker annotation (i.e. com/example/Redacted) to look for when redacting"
   )
+internal val KEY_UNREDACTED_ANNOTATION =
+  CompilerConfigurationKey<String>(
+    "The unredacted marker annotation (i.e. com/example/Unredacted) to look for when redacting"
+  )
 
 @OptIn(ExperimentalCompilerApi::class)
 @AutoService(CommandLineProcessor::class)
@@ -63,12 +67,26 @@ public class RedactedCommandLineProcessor : CommandLineProcessor {
         required = true,
         allowMultipleOccurrences = false,
       )
+
+    val OPTION_UNREDACTED_ANNOTATION =
+      CliOption(
+        optionName = "unredactedAnnotation",
+        valueDescription = "String",
+        description = KEY_UNREDACTED_ANNOTATION.toString(),
+        required = true,
+        allowMultipleOccurrences = false,
+      )
   }
 
   override val pluginId: String = "dev.zacsweers.redacted.compiler"
 
   override val pluginOptions: Collection<AbstractCliOption> =
-    listOf(OPTION_ENABLED, OPTION_REPLACEMENT_STRING, OPTION_REDACTED_ANNOTATION)
+    listOf(
+      OPTION_ENABLED,
+      OPTION_REPLACEMENT_STRING,
+      OPTION_REDACTED_ANNOTATION,
+      OPTION_UNREDACTED_ANNOTATION,
+    )
 
   override fun processOption(
     option: AbstractCliOption,
@@ -79,6 +97,7 @@ public class RedactedCommandLineProcessor : CommandLineProcessor {
       "enabled" -> configuration.put(KEY_ENABLED, value.toBoolean())
       "replacementString" -> configuration.put(KEY_REPLACEMENT_STRING, value)
       "redactedAnnotation" -> configuration.put(KEY_REDACTED_ANNOTATION, value)
+      "unredactedAnnotation" -> configuration.put(KEY_UNREDACTED_ANNOTATION, value)
       else -> error("Unknown plugin option: ${option.optionName}")
     }
 }

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedIrGenerationExtension.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedIrGenerationExtension.kt
@@ -25,11 +25,18 @@ internal class RedactedIrGenerationExtension(
   private val messageCollector: MessageCollector,
   private val replacementString: String,
   private val redactedAnnotationName: FqName,
+  private val unredactedAnnotationName: FqName,
 ) : IrGenerationExtension {
 
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
     val redactedTransformer =
-      RedactedIrVisitor(pluginContext, redactedAnnotationName, replacementString, messageCollector)
+      RedactedIrVisitor(
+        pluginContext,
+        redactedAnnotationName,
+        unredactedAnnotationName,
+        replacementString,
+        messageCollector,
+      )
     moduleFragment.transform(redactedTransformer, null)
   }
 }

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedIrVisitor.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedIrVisitor.kt
@@ -44,7 +44,17 @@ import org.jetbrains.kotlin.ir.expressions.addArgument
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetValueImpl
 import org.jetbrains.kotlin.ir.types.isArray
 import org.jetbrains.kotlin.ir.types.isString
-import org.jetbrains.kotlin.ir.util.*
+import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
+import org.jetbrains.kotlin.ir.util.file
+import org.jetbrains.kotlin.ir.util.getAllSuperclasses
+import org.jetbrains.kotlin.ir.util.hasAnnotation
+import org.jetbrains.kotlin.ir.util.isEnumClass
+import org.jetbrains.kotlin.ir.util.isEnumEntry
+import org.jetbrains.kotlin.ir.util.isFinalClass
+import org.jetbrains.kotlin.ir.util.isObject
+import org.jetbrains.kotlin.ir.util.isPrimitiveArray
+import org.jetbrains.kotlin.ir.util.primaryConstructor
+import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.util.OperatorNameConventions
 

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
@@ -40,11 +40,19 @@ public class RedactedComponentRegistrar : CompilerPluginRegistrar() {
       configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
     val replacementString = checkNotNull(configuration[KEY_REPLACEMENT_STRING])
     val redactedAnnotation = checkNotNull(configuration[KEY_REDACTED_ANNOTATION])
+    val unredactedAnnotation = checkNotNull(configuration[KEY_UNREDACTED_ANNOTATION])
     val redactedAnnotationClassId = ClassId.fromString(redactedAnnotation)
     val fqRedactedAnnotation = redactedAnnotationClassId.asSingleFqName()
+    val unredactedAnnotationClassId = ClassId.fromString(unredactedAnnotation)
+    val fqUnredactedAnnotation = unredactedAnnotationClassId.asSingleFqName()
 
     IrGenerationExtension.registerExtension(
-      RedactedIrGenerationExtension(messageCollector, replacementString, fqRedactedAnnotation)
+      RedactedIrGenerationExtension(
+        messageCollector,
+        replacementString,
+        fqRedactedAnnotation,
+        fqUnredactedAnnotation,
+      )
     )
 
     FirExtensionRegistrarAdapter.registerExtension(

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/FirRedactedExtensionRegistrar.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/FirRedactedExtensionRegistrar.kt
@@ -92,13 +92,14 @@ internal object FirRedactedDeclarationChecker : FirRegularClassChecker() {
       }
     }
 
-    if (declaration.classKind != ClassKind.CLASS) {
+    if (declaration.classKind != ClassKind.CLASS && declaration.classKind != ClassKind.INTERFACE) {
       report(KtErrorsRedacted.REDACTED_ON_NON_CLASS_ERROR)
       return
     }
 
     if (
-      !declaration.hasModifier(KtTokens.DATA_KEYWORD) &&
+      declaration.classKind != ClassKind.INTERFACE &&
+        !declaration.hasModifier(KtTokens.DATA_KEYWORD) &&
         !declaration.hasModifier(KtTokens.VALUE_KEYWORD)
     ) {
       report(KtErrorsRedacted.REDACTED_ON_NON_DATA_OR_VALUE_CLASS_ERROR)

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/FirRedactedExtensionRegistrar.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/FirRedactedExtensionRegistrar.kt
@@ -29,6 +29,9 @@ import org.jetbrains.kotlin.fir.declarations.FirDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.utils.isEnumClass
+import org.jetbrains.kotlin.fir.declarations.utils.isFinal
+import org.jetbrains.kotlin.fir.declarations.utils.isFromEnumClass
 import org.jetbrains.kotlin.fir.declarations.utils.isOverride
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
@@ -97,8 +100,13 @@ internal object FirRedactedDeclarationChecker : FirRegularClassChecker() {
       return
     }
 
+    if (declaration.isFromEnumClass || declaration.isEnumClass) {
+      report(KtErrorsRedacted.REDACTED_ON_ENUM_CLASS_ERROR)
+      return
+    }
+
     if (
-      declaration.classKind != ClassKind.INTERFACE &&
+      declaration.isFinal &&
         !declaration.hasModifier(KtTokens.DATA_KEYWORD) &&
         !declaration.hasModifier(KtTokens.VALUE_KEYWORD)
     ) {

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/KtErrorsRedacted.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/KtErrorsRedacted.kt
@@ -26,6 +26,8 @@ internal object KtErrorsRedacted {
     error0<PsiElement>(SourceElementPositioningStrategies.NAME_IDENTIFIER)
   val REDACTED_ON_NON_CLASS_ERROR by
     error0<PsiElement>(SourceElementPositioningStrategies.NAME_IDENTIFIER)
+  val REDACTED_ON_ENUM_CLASS_ERROR by
+    error0<PsiElement>(SourceElementPositioningStrategies.NAME_IDENTIFIER)
   val REDACTED_ON_NON_DATA_OR_VALUE_CLASS_ERROR by
     error0<PsiElement>(SourceElementPositioningStrategies.NAME_IDENTIFIER)
   val REDACTED_ON_VALUE_CLASS_PROPERTY_ERROR by

--- a/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
+++ b/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
@@ -25,6 +25,7 @@ import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
 import dev.zacsweers.redacted.compiler.RedactedCommandLineProcessor.Companion.OPTION_ENABLED
 import dev.zacsweers.redacted.compiler.RedactedCommandLineProcessor.Companion.OPTION_REDACTED_ANNOTATION
 import dev.zacsweers.redacted.compiler.RedactedCommandLineProcessor.Companion.OPTION_REPLACEMENT_STRING
+import dev.zacsweers.redacted.compiler.RedactedCommandLineProcessor.Companion.OPTION_UNREDACTED_ANNOTATION
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
@@ -58,6 +59,10 @@ class RedactedPluginTest(private val useK2: Boolean) {
       @Retention(BINARY)
       @Target(PROPERTY, CLASS)
       annotation class Redacted
+
+      @Retention(BINARY)
+      @Target(PROPERTY)
+      annotation class Unredacted
       """,
     )
 
@@ -480,6 +485,10 @@ class RedactedPluginTest(private val useK2: Boolean) {
           processor.option(
             OPTION_REDACTED_ANNOTATION,
             "dev/zacsweers/redacted/compiler/test/Redacted",
+          ),
+          processor.option(
+            OPTION_UNREDACTED_ANNOTATION,
+            "dev/zacsweers/redacted/compiler/test/Unredacted",
           ),
         )
       inheritClassPath = true

--- a/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
+++ b/redacted-compiler-plugin/src/test/kotlin/dev/zacsweers/redacted/compiler/RedactedPluginTest.kt
@@ -116,7 +116,7 @@ class RedactedPluginTest(private val useK2: Boolean) {
     assertThat(result.messages).contains("NonClass.kt:")
     // TODO K2 doesn't support custom error messages yet
     if (!useK2) {
-      assertThat(result.messages).contains("@Redacted is only supported on data or value classes!")
+      assertThat(result.messages).contains("@Redacted does not support enum classes or entries!")
     }
   }
 

--- a/sample/src/jvmTest/kotlin/dev/zacsweers/redacted/sample/SmokeTest.kt
+++ b/sample/src/jvmTest/kotlin/dev/zacsweers/redacted/sample/SmokeTest.kt
@@ -17,9 +17,29 @@ package dev.zacsweers.redacted.sample
 
 import com.google.common.truth.Truth.assertThat
 import dev.zacsweers.redacted.annotations.Redacted
+import dev.zacsweers.redacted.annotations.Unredacted
 import org.junit.Test
 
 class SmokeTest {
+
+  @Test
+  fun supertypeRedactedExample() {
+    val data = SuperRedacted("Bob", "2815551234")
+    assertThat(data.toString()).isEqualTo("SuperRedacted(name=Bob, phoneNumber=██)")
+  }
+
+  @Test
+  fun unredactedPropertyOnRedactedClassExample() {
+    val data = RedactedClass("Bob", "2815551234")
+    assertThat(data.toString()).isEqualTo("RedactedClass(name=Bob, phoneNumber=██)")
+  }
+
+  @Redacted interface Base
+
+  data class SuperRedacted(@Unredacted val name: String, val phoneNumber: String) : Base
+
+  @Redacted data class RedactedClass(@Unredacted val name: String, val phoneNumber: String)
+
   @Test
   fun userExample() {
     val user = User("Bob", "2815551234")

--- a/sample/src/jvmTest/kotlin/dev/zacsweers/redacted/sample/SmokeTest.kt
+++ b/sample/src/jvmTest/kotlin/dev/zacsweers/redacted/sample/SmokeTest.kt
@@ -23,6 +23,46 @@ import org.junit.Test
 class SmokeTest {
 
   @Test
+  fun abstractExample() {
+    val secretChild = AbstractBase.SecretChild("private")
+    assertThat(secretChild.toString()).isEqualTo("SecretChild(redact=██)")
+  }
+
+  @Test
+  fun unredactedAbstractExample() {
+    val notSoSecretChild = AbstractBase.NotSoSecretChild("public")
+    assertThat(notSoSecretChild.toString()).isEqualTo("NotSoSecretChild(unredacted=public)")
+  }
+
+  @Redacted
+  abstract class AbstractBase {
+
+    data class SecretChild(val redact: String) : AbstractBase()
+
+    data class NotSoSecretChild(@Unredacted val unredacted: String) : AbstractBase()
+  }
+
+  @Test
+  fun sealedExample() {
+    val secretChild = SecretParent.SecretChild("private")
+    assertThat(secretChild.toString()).isEqualTo("SecretChild(redact=██)")
+  }
+
+  @Test
+  fun unredactedSealedExample() {
+    val notSoSecretChild = SecretParent.NotSoSecretChild("public")
+    assertThat(notSoSecretChild.toString()).isEqualTo("NotSoSecretChild(unredacted=public)")
+  }
+
+  @Redacted
+  sealed class SecretParent {
+
+    data class SecretChild(val redact: String) : SecretParent()
+
+    data class NotSoSecretChild(@Unredacted val unredacted: String) : SecretParent()
+  }
+
+  @Test
   fun supertypeRedactedExample() {
     val data = SuperRedacted("Bob", "2815551234")
     assertThat(data.toString()).isEqualTo("SuperRedacted(name=Bob, phoneNumber=██)")


### PR DESCRIPTION
Our team at Block has a use-case in which we'd like to have opt-out behavior for certain classes and a way to enforce that APIs are only provided redacted classes.

I remember similar situations where you've mentioned preferring the limited scope for the library and that maintaining a fork is best, the team wanted to suggest the changes anyway and they may be useful for others to find.