### PR TITLE
Allow `@Unredacted` classes & `@Redacted` child objects

### DIFF
--- a/redacted-compiler-plugin-annotations/src/commonMain/kotlin/dev/zacsweers/redacted/annotations/Unredacted.kt
+++ b/redacted-compiler-plugin-annotations/src/commonMain/kotlin/dev/zacsweers/redacted/annotations/Unredacted.kt
@@ -16,6 +16,7 @@
 package dev.zacsweers.redacted.annotations
 
 import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.PROPERTY
 
 /**
@@ -33,4 +34,4 @@ import kotlin.annotation.AnnotationTarget.PROPERTY
  * println(user) // User(name = "Bob", phoneNumber = "██")
  * ```
  */
-@Retention(BINARY) @Target(PROPERTY) public annotation class Unredacted
+@Retention(BINARY) @Target(PROPERTY, CLASS) public annotation class Unredacted

--- a/sample/src/jvmTest/kotlin/dev/zacsweers/redacted/sample/SmokeTest.kt
+++ b/sample/src/jvmTest/kotlin/dev/zacsweers/redacted/sample/SmokeTest.kt
@@ -34,12 +34,27 @@ class SmokeTest {
     assertThat(notSoSecretChild.toString()).isEqualTo("NotSoSecretChild(unredacted=public)")
   }
 
+  @Test
+  fun unredactedClassAbstractExample() {
+    val notAtAllSecretChild = AbstractBase.NotAtAllSecretChild("public")
+    assertThat(notAtAllSecretChild.toString()).isEqualTo("NotAtAllSecretChild(unredacted=public)")
+  }
+
+  @Test
+  fun redactedObjectAbstractExample() {
+    assertThat(AbstractBase.ProplessChild.toString()).isEqualTo("ProplessChild()")
+  }
+
   @Redacted
   abstract class AbstractBase {
 
     data class SecretChild(val redact: String) : AbstractBase()
 
     data class NotSoSecretChild(@Unredacted val unredacted: String) : AbstractBase()
+
+    @Unredacted data class NotAtAllSecretChild(val unredacted: String) : AbstractBase()
+
+    data object ProplessChild : AbstractBase()
   }
 
   @Test
@@ -54,12 +69,27 @@ class SmokeTest {
     assertThat(notSoSecretChild.toString()).isEqualTo("NotSoSecretChild(unredacted=public)")
   }
 
+  @Test
+  fun unredactedClassSealedExample() {
+    val notAtAllSecretChild = SecretParent.NotAtAllSecretChild("public")
+    assertThat(notAtAllSecretChild.toString()).isEqualTo("NotAtAllSecretChild(unredacted=public)")
+  }
+
+  @Test
+  fun redactedObjectSealedExample() {
+    assertThat(SecretParent.ProplessChild.toString()).isEqualTo("ProplessChild()")
+  }
+
   @Redacted
   sealed class SecretParent {
 
     data class SecretChild(val redact: String) : SecretParent()
 
     data class NotSoSecretChild(@Unredacted val unredacted: String) : SecretParent()
+
+    @Unredacted data class NotAtAllSecretChild(val unredacted: String) : AbstractBase()
+
+    data object ProplessChild : SecretParent()
   }
 
   @Test


### PR DESCRIPTION
Some small improvements to my previous changes:

- Allow `@Unredacted` to be applied to a class, only when a supertype is `@Redacted`
- Allow `@Redacted` supertypes to be inherited by objects, only when the child does not implement a custom `toString` method
- Fail compilation when `@Unredacted` and `@Redacted` are applied to the same class