### PR TITLE
Fix command line parsing of multiple args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 **Unreleased**
 --------------
 
+- **Fix**: Fix CLI parsing for multiple custom annotations. Note that while the previous version was broken, it would have _also_ failed compilation so there shouldn't be a chance that broken redactions would have made it into a production build.
+- Update to Kotlin `2.1.10`.
+- Build against Gradle `8.12.1`.
+
 1.12.0
 ------
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ spotless {
   format("misc") {
     target("*.gradle", "*.md", ".gitignore")
     trimTrailingWhitespace()
-    indentWithSpaces(2)
+    leadingTabsToSpaces(2)
     endWithNewline()
   }
   kotlin {

--- a/redacted-compiler-plugin-gradle/build.gradle.kts
+++ b/redacted-compiler-plugin-gradle/build.gradle.kts
@@ -85,7 +85,7 @@ spotless {
   format("misc") {
     target("*.gradle", "*.md", ".gitignore")
     trimTrailingWhitespace()
-    indentWithSpaces(2)
+    leadingTabsToSpaces(2)
     endWithNewline()
   }
   kotlin {

--- a/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
+++ b/redacted-compiler-plugin-gradle/src/main/kotlin/dev/zacsweers/redacted/gradle/RedactedGradleSubplugin.kt
@@ -70,10 +70,10 @@ public class RedactedGradleSubplugin : KotlinCompilerPluginSupportPlugin {
       listOf(
         SubpluginOption(key = "enabled", value = enabled.toString()),
         SubpluginOption(key = "replacementString", value = extension.replacementString.get()),
-        SubpluginOption(key = "redactedAnnotations", value = annotations.get().joinToString(",")),
+        SubpluginOption(key = "redactedAnnotations", value = annotations.get().joinToString(":")),
         SubpluginOption(
           key = "unredactedAnnotations",
-          value = unredactedAnnotations.get().joinToString(","),
+          value = unredactedAnnotations.get().joinToString(":"),
         ),
       )
     }

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/RedactedPlugin.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.name.ClassId
 
@@ -41,24 +40,21 @@ public class RedactedComponentRegistrar : CompilerPluginRegistrar() {
       configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
     val replacementString = checkNotNull(configuration[KEY_REPLACEMENT_STRING])
     val redactedAnnotations =
-      checkNotNull(configuration[KEY_REDACTED_ANNOTATIONS]).splitToSequence(",").mapTo(
+      checkNotNull(configuration[KEY_REDACTED_ANNOTATIONS]).splitToSequence(":").mapTo(
         LinkedHashSet()
       ) {
         ClassId.fromString(it)
       }
     val unRedactedAnnotations =
-      checkNotNull(configuration[KEY_UNREDACTED_ANNOTATION]).splitToSequence(",").mapTo(
+      checkNotNull(configuration[KEY_UNREDACTED_ANNOTATION]).splitToSequence(":").mapTo(
         LinkedHashSet()
       ) {
         ClassId.fromString(it)
       }
-    val usesK2 = configuration.languageVersionSettings.languageVersion.usesK2
 
-    if (usesK2) {
-      FirExtensionRegistrarAdapter.registerExtension(
-        FirRedactedExtensionRegistrar(redactedAnnotations, unRedactedAnnotations)
-      )
-    }
+    FirExtensionRegistrarAdapter.registerExtension(
+      FirRedactedExtensionRegistrar(redactedAnnotations, unRedactedAnnotations)
+    )
     IrGenerationExtension.registerExtension(
       RedactedIrGenerationExtension(
         messageCollector,


### PR DESCRIPTION
Commas can't be used because it breaks CLI arg parsing