### PR TITLE
 Handle failed error message when no redacted properties

### DIFF
--- a/compiler-tests/src/test/data/diagnostic/CustomToString.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/CustomToString.fir.diag.txt
@@ -1,1 +1,0 @@
-/CustomToString.kt:(142,150): error: @Redacted is only supported on data or value classes that do *not* have a custom toString() function. Please remove the function or remove the @Redacted annotations.

--- a/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedClass.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedClass.fir.diag.txt
@@ -1,0 +1,1 @@
+/CustomToStringRedactedClass.kt:(155,163): error: @Redacted is only supported on data or value classes that do *not* have a custom toString() function. Please remove the function or remove the @Redacted annotations.

--- a/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedClass.kt
+++ b/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedClass.kt
@@ -1,5 +1,6 @@
 // RENDER_DIAGNOSTICS_FULL_TEXT
 
-data class CustomToString(@Redacted val a: Int) {
+@Redacted
+data class CustomToStringRedactedClass(val a: Int) {
   override fun <!REDACTED_ERROR!>toString<!>(): String = "foo"
 }

--- a/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedProperty.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedProperty.fir.diag.txt
@@ -1,0 +1,1 @@
+/CustomToStringRedactedProperty.kt:(158,166): error: @Redacted is only supported on data or value classes that do *not* have a custom toString() function. Please remove the function or remove the @Redacted annotations.

--- a/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedProperty.kt
+++ b/compiler-tests/src/test/data/diagnostic/CustomToStringRedactedProperty.kt
@@ -1,0 +1,5 @@
+// RENDER_DIAGNOSTICS_FULL_TEXT
+
+data class CustomToStringRedactedProperty(@Redacted val a: Int) {
+  override fun <!REDACTED_ERROR!>toString<!>(): String = "foo"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/redacted/compiler/DiagnosticTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/redacted/compiler/DiagnosticTestGenerated.java
@@ -27,9 +27,15 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
   }
 
   @Test
-  @TestMetadata("CustomToString.kt")
-  public void testCustomToString() {
-    runTest("compiler-tests/src/test/data/diagnostic/CustomToString.kt");
+  @TestMetadata("CustomToStringRedactedClass.kt")
+  public void testCustomToStringRedactedClass() {
+    runTest("compiler-tests/src/test/data/diagnostic/CustomToStringRedactedClass.kt");
+  }
+
+  @Test
+  @TestMetadata("CustomToStringRedactedProperty.kt")
+  public void testCustomToStringRedactedProperty() {
+    runTest("compiler-tests/src/test/data/diagnostic/CustomToStringRedactedProperty.kt");
   }
 
   @Test

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/RedactedFirExtensionRegistrar.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/RedactedFirExtensionRegistrar.kt
@@ -69,14 +69,14 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
   context(context: CheckerContext, reporter: DiagnosticReporter)
   override fun check(declaration: FirClass) {
     val classRedactedAnnotations =
-      context.session.redactedAnnotations.mapNotNull {
-        declaration.getAnnotationByClassId(it, context.session)
+      context.session.redactedAnnotations.mapNotNull { classId ->
+        declaration.getAnnotationByClassId(classId, context.session)?.let { it to classId }
+      }
+    val classUnRedactedAnnotations =
+      context.session.unRedactedAnnotations.mapNotNull { classId ->
+        declaration.getAnnotationByClassId(classId, context.session)?.let { it to classId }
       }
     val classIsRedacted = classRedactedAnnotations.isNotEmpty()
-    val classUnRedactedAnnotations =
-      context.session.unRedactedAnnotations.mapNotNull {
-        declaration.getAnnotationByClassId(it, context.session)
-      }
     val classIsUnRedacted = classUnRedactedAnnotations.isNotEmpty()
     val redactedSupertype: RedactedSupertype? by unsafeLazy {
       for (ref in declaration.superTypeRefs) {
@@ -117,9 +117,15 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
     val anyRedacted = redactedProperties.isNotEmpty()
     val anyUnredacted = unredactedProperties.isNotEmpty()
 
-    val redactedName = { redactedProperties.values.firstOrNull()?.second?.shortClassName?.asString() }
+    val redactedName = {
+      redactedProperties.values.firstOrNull()?.second?.shortClassName?.asString()
+        ?: classRedactedAnnotations.firstOrNull()?.second?.shortClassName?.asString()
+    }
 
-    val unRedactedName = { unredactedProperties.values.firstOrNull()?.second?.shortClassName?.asString() }
+    val unRedactedName = {
+      unredactedProperties.values.firstOrNull()?.second?.shortClassName?.asString()
+        ?: classUnRedactedAnnotations.firstOrNull()?.second?.shortClassName?.asString()
+    }
 
     if (classIsRedacted || redactedSupertype != null || classIsUnRedacted || anyRedacted) {
       if (customToStringFunction != null) {
@@ -160,7 +166,7 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
       }
       if (declaration.classKind.isObject) {
         if (redactedSupertype == null) {
-          val classAnnotation = classRedactedAnnotations.first()
+          val classAnnotation = classRedactedAnnotations.first().first
           reporter.reportOn(
             classAnnotation.source,
             RedactedDiagnostics.REDACTED_ERROR,
@@ -169,7 +175,7 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
           return
         } else if (classIsUnRedacted) {
           reporter.reportOn(
-            classUnRedactedAnnotations.firstOrNull()?.source,
+            classUnRedactedAnnotations.firstOrNull()?.first?.source,
             RedactedDiagnostics.REDACTED_ERROR,
             "@${unRedactedName()} is useless on object classes.",
           )
@@ -203,7 +209,7 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
       if (!(classIsRedacted xor anyRedacted xor (redactedSupertype != null))) {
         val redactedName =
           redactedProperties.values.firstOrNull()?.second
-            ?: classRedactedAnnotations.firstOrNull()?.toAnnotationClassIdSafe(context.session)
+            ?: classRedactedAnnotations.firstOrNull()?.first?.toAnnotationClassIdSafe(context.session)
             ?: redactedSupertype?.redactedClassId
             ?: error("Not possible!")
 
@@ -222,7 +228,7 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
 
         if (classIsRedacted) {
           reporter.reportOn(
-            classRedactedAnnotations.first().source,
+            classRedactedAnnotations.first().first.source,
             RedactedDiagnostics.REDACTED_ERROR,
             message,
           )

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/RedactedFirExtensionRegistrar.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/RedactedFirExtensionRegistrar.kt
@@ -209,7 +209,10 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
       if (!(classIsRedacted xor anyRedacted xor (redactedSupertype != null))) {
         val redactedName =
           redactedProperties.values.firstOrNull()?.second
-            ?: classRedactedAnnotations.firstOrNull()?.first?.toAnnotationClassIdSafe(context.session)
+            ?: classRedactedAnnotations
+              .firstOrNull()
+              ?.first
+              ?.toAnnotationClassIdSafe(context.session)
             ?: redactedSupertype?.redactedClassId
             ?: error("Not possible!")
 

--- a/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/RedactedFirExtensionRegistrar.kt
+++ b/redacted-compiler-plugin/src/main/kotlin/dev/zacsweers/redacted/compiler/fir/RedactedFirExtensionRegistrar.kt
@@ -117,9 +117,9 @@ internal object FirRedactedDeclarationChecker : FirClassChecker(MppCheckerKind.C
     val anyRedacted = redactedProperties.isNotEmpty()
     val anyUnredacted = unredactedProperties.isNotEmpty()
 
-    val redactedName = { redactedProperties.values.first().second.shortClassName.asString() }
+    val redactedName = { redactedProperties.values.firstOrNull()?.second?.shortClassName?.asString() }
 
-    val unRedactedName = { unredactedProperties.values.first().second.shortClassName.asString() }
+    val unRedactedName = { unredactedProperties.values.firstOrNull()?.second?.shortClassName?.asString() }
 
     if (classIsRedacted || redactedSupertype != null || classIsUnRedacted || anyRedacted) {
       if (customToStringFunction != null) {


### PR DESCRIPTION
I have a class like:

```kotlin
@Redacted
@JvmInline
value class Password(val value: String) {
  override fun toString(): String = value
}
```

Which threw an error when I tried to compile like below:

```
Caused by: java.util.NoSuchElementException: Collection is empty.
	at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:208)
	at dev.zacsweers.redacted.compiler.fir.FirRedactedDeclarationChecker.check$lambda$8(RedactedFirExtensionRegistrar.kt:120)
	at dev.zacsweers.redacted.compiler.fir.FirRedactedDeclarationChecker.check(RedactedFirExtensionRegistrar.kt:129)
	at dev.zacsweers.redacted.compiler.fir.FirRedactedDeclarationChecker.check(RedactedFirExtensionRegistrar.kt:62)
	at org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckersDiagnosticComponent.visitRegularClass(DeclarationCheckersDiagnosticComponent.kt:275)
	... 52 more
```

It wasn't clear what the actual problem was - it turns out that the compiler plugin was trying to tell me not to implement toString, but because I didn't have any redacted properties on my class the compiler plugin was throwing a wobbly trying to figure out the annotation name and the error message.

Added a basic test to catch this, let me know if it needs anything more thorough.